### PR TITLE
fix(#21): rearrange driver makefile to fix i2c/clk probing

### DIFF
--- a/kernel/drivers/Makefile
+++ b/kernel/drivers/Makefile
@@ -5,6 +5,9 @@
 # Rewritten to use lists instead of if-statements.
 #
 
+#common clk code
+obj-y				+= clk/
+
 obj-y				+= irqchip/
 obj-y				+= bus/
 
@@ -139,8 +142,6 @@ obj-$(CONFIG_VHOST_RING)	+= vhost/
 obj-$(CONFIG_VLYNQ)		+= vlynq/
 obj-$(CONFIG_STAGING)		+= staging/
 obj-y				+= platform/
-#common clk code
-obj-y				+= clk/
 
 obj-$(CONFIG_MAILBOX)		+= mailbox/
 obj-$(CONFIG_HWSPINLOCK)	+= hwspinlock/


### PR DESCRIPTION
Fixes #21 by moving `clk` to top of makefile, as suggested by https://stackoverflow.com/questions/30166717/how-to-fix-error-on-clk-getcore-clk-during-probing-driver-i2c-msm-v2